### PR TITLE
Ignore prefs namespace in getPreferences

### DIFF
--- a/data/xql/getPreferences.xql
+++ b/data/xql/getPreferences.xql
@@ -44,12 +44,12 @@ return
             </output:serialization-parameters>
         let $data := 
             map:merge((
-                $file//entry ! map:entry(./string(@key), ./string(@value)), 
-                $projectFile//entry ! map:entry(./string(@key), ./string(@value)),
+                $file//*[local-name() = 'entry'] ! map:entry(./string(@key), ./string(@value)), 
+                $projectFile//*[local-name() = 'entry'] ! map:entry(./string(@key), ./string(@value)),
                 map:entry(
                     "web-components",
                     map:merge(
-                        $file//web-component ! map:entry(./string(@key),
+                        ($file//*[local-name() = 'web-component'], $projectFile//*[local-name() = 'web-component']) ! map:entry(./string(@key),
                             map:merge(
                                 .//option ! map:entry(./string(@key), ./string(@value))
                             )


### PR DESCRIPTION
## Description, Context and related Issue
getPreferences function ignores namespace to load project specific config.

Refs #14 

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Overview
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Backend/blob/develop/CONTRIBUTING.md) document.
- I have added tests to cover my changes at [testing](https://github.com/Edirom/Edirom-Online-Backend/tree/develop/testing)
- All new and existing tests passed.
